### PR TITLE
removing secrets manager dependency

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -26,7 +26,7 @@ env:
   TF_BACKEND_BUCKET_REGION: ${{ secrets.TF_BACKEND_BUCKET_REGION }}
   TF_VARS: >-
     -var="max_gems_per_day=${{ vars.MAX_GEMS_PER_DAY }}"
-    -var="discord_public_key_secrets_arn=${{ secrets.DISCORD_PUBLIC_KEY_SECRETS_ARN }}"
+    -var="discord_public_key_secret_arn=${{ secrets.DISCORD_PUBLIC_KEY_SECRETS_ARN }}"
     -var="discord_gems_channel=${{ vars.DISCORD_GEMS_CHANNEL }}"
     -var="discord_bot_token_secret_arn=${{ secrets.DISCORD_BOT_TOKEN_SECRETS_ARN }}"
     -var="prefix=${{ vars.PREFIX }}"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To get this application to work, you must first create a discord bot 🤖 to int
 | Variable Name | Description | Default Value |
 | ------------- | ------------- | ------------- |
 | `prefix` | Resource names to prefix with | None |
-| `discord_public_key_secrets_arn` | A secrets manager arn for discord public key | None |
+| `discord_public_key_secret_arn` | A secrets manager arn for discord public key | None |
 | `max_gems_per_day` | Maximum gems one can give per day | 5 |
 | `lambda_max_concurrency` | Maximum number of lambdas that can run at a given time | 5 |
 | `discord_gems_channel` | Discord channel to use the gem command in. Do not pass this value or set empty string ("") if you want to give gem from any channel | "" |

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from typing import List, Set, Type
 
 LAMBDA_ENVIRONMENT_VARIABLES: Set[str] = {
     "gems_table_name",
-    "discord_public_key_secrets_arn",
+    "discord_public_key_secret_arn",
     "max_gems_per_day",
     "discord_gems_channel",
     "monthly_cron_rule",

--- a/src/handler.py
+++ b/src/handler.py
@@ -12,7 +12,6 @@ from communication import send_channel_message
 from constants import load_environment_variables
 from dynamo import (get_monthly_rank, insert_gem_to_dynamo,
                     sender_gem_count_today)
-from secrets_manager_helper import get_cached_secret
 
 PING_PONG = {"type": 1}
 
@@ -33,8 +32,7 @@ def handler(event, _):
 
     # verify the signature
     try:
-        verify_signature(event, get_cached_secret(
-            env_vars.discord_public_key_secrets_arn))
+        verify_signature(event, env_vars.discord_public_key)
     except Exception as e:
         raise Exception(f"[UNAUTHORIZED] Invalid request signature: {e}")
 
@@ -111,10 +109,7 @@ def gem_handler(body: Dict[str, Any], env_vars):
 
 
 def _handle_trigger_from_cron(env_vars):
-    discord_bot_token: str = get_cached_secret(
-        env_vars.discord_bot_token_secret_arn
-    )
-
+    """Handles auto triggers from cron job"""
     last_month_last_day = datetime.datetime.today().replace(day=1) - datetime.timedelta(
         days=1
     )
@@ -125,7 +120,7 @@ def _handle_trigger_from_cron(env_vars):
         rank, f"**:calendar: Top members of {calendar.month_name[month]} :calendar:**")
 
     send_channel_message(
-        discord_bot_token,
+        env_vars.discord_bot_token,
         int(env_vars.discord_gems_channel),
         message
     )

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -6,7 +6,7 @@ locals {
       policy               = data.aws_iam_policy_document.discord_gems_policy
       handler              = "handler.handler"
       timeout              = 120
-      memory_size          = 128
+      memory_size          = 512
       publish_lambda       = true
       reserved_concurrency = var.lambda_reserved_concurrency
       env_variables = {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -10,12 +10,12 @@ locals {
       publish_lambda       = true
       reserved_concurrency = var.lambda_reserved_concurrency
       env_variables = {
-        gems_table_name                = aws_dynamodb_table.gems_table.name
-        discord_public_key_secrets_arn = var.discord_public_key_secrets_arn
-        max_gems_per_day               = var.max_gems_per_day
-        discord_gems_channel           = var.discord_gems_channel
-        monthly_cron_rule              = aws_cloudwatch_event_rule.monthly_cron_rule.arn
-        discord_bot_token_secret_arn   = var.discord_bot_token_secret_arn
+        gems_table_name      = aws_dynamodb_table.gems_table.name
+        discord_public_key   = data.aws_secretsmanager_secret_version.discord_bot_token.secret_string
+        max_gems_per_day     = var.max_gems_per_day
+        discord_gems_channel = var.discord_gems_channel
+        monthly_cron_rule    = aws_cloudwatch_event_rule.monthly_cron_rule.arn
+        discord_bot_token    = data.aws_secretsmanager_secret_version.discord_bot_token.secret_string
       }
     }
   }

--- a/terraform/lambda_iam_policy.tf
+++ b/terraform/lambda_iam_policy.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "discord_gems_policy" {
     ]
     resources = [
       var.discord_bot_token_secret_arn,
-      var.discord_public_key_secrets_arn,
+      var.discord_public_key_secret_arn,
       "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
     ]
   }

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,15 @@
+data "aws_secretsmanager_secret" "discord_public_key_secret" {
+  arn = var.discord_public_key_secret_arn
+}
+
+data "aws_secretsmanager_secret" "discord_bot_token_secret" {
+  arn = var.discord_bot_token_secret_arn
+}
+
+data "aws_secretsmanager_secret_version" "discord_public_key" {
+  secret_id = data.aws_secretsmanager_secret.discord_public_key_secret.id
+}
+
+data "aws_secretsmanager_secret_version" "discord_bot_token" {
+  secret_id = data.aws_secretsmanager_secret.discord_bot_token_secret.id
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "prefix" {
   description = "AWS Resources name prefix"
 }
 
-variable "discord_public_key_secrets_arn" {
+variable "discord_public_key_secret_arn" {
   type        = string
   description = "Discord bot public key in general information page"
   sensitive   = true


### PR DESCRIPTION
Keeping the discord tokens in a secret and having the lambda fetch it was becoming **cumbersome** and **expensive**. So we've decided to remove the **lambda** code that fetches the secret from secrets manager on **demand**. Instead we're using the **lambda** **env**. Secrets **still live in secrets manager**. But **terrafrom** fetches and **inserts** it into lambda **env** now.

We've also given more **memory** to the lambda to help it respond to **requests** faster.