### PR TITLE
typo fixes for discord secret keys

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,6 +1,2 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-
-data "aws_secretsmanager_secret_version" "discord_bot_token" {
-  secret_id = var.discord_bot_token_secret_arn
-}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -11,7 +11,7 @@ locals {
       reserved_concurrency = var.lambda_reserved_concurrency
       env_variables = {
         gems_table_name      = aws_dynamodb_table.gems_table.name
-        discord_public_key   = data.aws_secretsmanager_secret_version.discord_bot_token.secret_string
+        discord_public_key   = data.aws_secretsmanager_secret_version.discord_public_key.secret_string
         max_gems_per_day     = var.max_gems_per_day
         discord_gems_channel = var.discord_gems_channel
         monthly_cron_rule    = aws_cloudwatch_event_rule.monthly_cron_rule.arn

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,15 +1,7 @@
-data "aws_secretsmanager_secret" "discord_public_key_secret" {
-  arn = var.discord_public_key_secret_arn
-}
-
-data "aws_secretsmanager_secret" "discord_bot_token_secret" {
-  arn = var.discord_bot_token_secret_arn
-}
-
 data "aws_secretsmanager_secret_version" "discord_public_key" {
-  secret_id = data.aws_secretsmanager_secret.discord_public_key_secret.id
+  secret_id = var.discord_public_key_secret_arn
 }
 
 data "aws_secretsmanager_secret_version" "discord_bot_token" {
-  secret_id = data.aws_secretsmanager_secret.discord_bot_token_secret.id
+  secret_id = var.discord_bot_token_secret_arn
 }


### PR DESCRIPTION
Earlier pr had a typo that caused the pipeline to break. This pr fixes that.