### PR TITLE
removing secrets cache lambda layer integration for now, moving to arm

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -39,9 +39,10 @@ resource "aws_lambda_function" "lambda_functions" {
   runtime                        = local.lambda_python_version
   timeout                        = lookup(each.value, "timeout", 120)
   memory_size                    = lookup(each.value, "memory_size", 128)
-  layers                         = [aws_lambda_layer_version.lambda_layer.arn, "arn:aws:lambda:${data.aws_region.current.name}:${var.secrets_manager_cache_lambda_layer_account_id}:layer:AWS-Parameters-and-Secrets-Lambda-Extension:${var.secrets_manager_cache_lambda_layer_version}"]
+  layers                         = [aws_lambda_layer_version.lambda_layer.arn]
   publish                        = lookup(each.value, "publish_lambda", false)
   reserved_concurrent_executions = lookup(each.value, "reserved_concurrency", -1)
+  architectures                  = "arm64"
   environment {
     variables = lookup(each.value, "env_variables", {})
   }


### PR DESCRIPTION
- Removing the attachment of secrets cache layer (still passed in as vars to terraform for future refs)
- Moving the lambda to save costs