### PR TITLE
Adding support for `$gem-number` template for sending gems

### DIFF
--- a/src/command.py
+++ b/src/command.py
@@ -1,7 +1,7 @@
 """Discord slash command helpers"""
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
-
 
 @dataclass
 class GemsMessage:
@@ -50,33 +50,12 @@ class GemsMessage:
 
 
 class GemsCounterFromMessage:
-    def __get_int_converted_gem_count(self, gem_count_string: str):
-        if gem_count_string.isdigit():
-            return int(gem_count_string)
-        try:
-            gem_count_float = float(gem_count_string)
-            return int(gem_count_float)
-        except ValueError:
-            return 0
-
     def _get_gem_count_from_gem_string(self, message: str):
-        gem_message_string_anchor = '$gem-'
-        if message.count(gem_message_string_anchor) == 0:
+        gem_message_string_regex = r'(?:\s|^)\$gem-\d+(?:\s|$)'
+        gem_message_words = re.findall(gem_message_string_regex, message)
+        if len(gem_message_words) == 0:
             return 0
-
-        gem_message_words = message.split()
-        # consider first $gem-number for multiple $gem-number in message
-        for message_segment in gem_message_words:
-            if gem_message_string_anchor in message_segment:
-                if message_segment.count(gem_message_string_anchor) > 1:
-                    return 0
-                
-                gem_count_string = message_segment.replace(gem_message_string_anchor, '')
-                gem_count = self.__get_int_converted_gem_count(gem_count_string)
-                if gem_count > 0:
-                    return gem_count
-
-        return 0
+        return int(re.search('\d+', gem_message_words[0]).group())
 
     def get_gem_count_in_message(self, message: str):
         gem_count_in_message = message.count("💎")

--- a/src/message_gems_parser.py
+++ b/src/message_gems_parser.py
@@ -1,14 +1,14 @@
 import re
 
 def get_gem_count_from_gem_string(message: str):
-    gem_template_string_anchor = '$gem-'
-    gem_message_string_regex = fr'(?:\s|^)\{gem_template_string_anchor}\d+(?:\s|$)'
-    gem_message_word = re.search(gem_message_string_regex, message)
-    if not gem_message_word:
+    gem_template_string_anchor = '-gems'
+    gem_message_string_regex = fr'(?:\s|^)\d+{gem_template_string_anchor}(?:\s|$)'
+    probable_gem_message_word = re.search(gem_message_string_regex, message)
+    if not probable_gem_message_word:
         return 0
     
-    gem_message_word_group = gem_message_word.group().strip()
-    return int(gem_message_word_group[len(gem_template_string_anchor):])
+    gem_message_word = probable_gem_message_word.group().strip()
+    return int(gem_message_word[: -len(gem_template_string_anchor)])
 
 def get_gem_count_in_message(message: str):
     gem_count_in_message = message.count("💎")

--- a/src/message_gems_parser.py
+++ b/src/message_gems_parser.py
@@ -1,14 +1,14 @@
 import re
 
 def get_gem_count_from_gem_string(message: str):
-    gem_template_string_anchor = '-gems'
-    gem_message_string_regex = fr'(?:\s|^)\d+{gem_template_string_anchor}(?:\s|$)'
+    gem_template_string_anchor = 'gems-'
+    gem_message_string_regex = fr'(?:\s|^){gem_template_string_anchor}\d+(?:\s|$)'
     probable_gem_message_word = re.search(gem_message_string_regex, message)
     if not probable_gem_message_word:
         return 0
     
     gem_message_word = probable_gem_message_word.group().strip()
-    return int(gem_message_word[: -len(gem_template_string_anchor)])
+    return int(gem_message_word[len(gem_template_string_anchor):])
 
 def get_gem_count_in_message(message: str):
     gem_count_in_message = message.count("💎")

--- a/src/message_gems_parser.py
+++ b/src/message_gems_parser.py
@@ -1,0 +1,18 @@
+import re
+
+def get_gem_count_from_gem_string(message: str):
+    gem_template_string_anchor = '$gem-'
+    gem_message_string_regex = fr'(?:\s|^)\{gem_template_string_anchor}\d+(?:\s|$)'
+    gem_message_word = re.search(gem_message_string_regex, message)
+    if not gem_message_word:
+        return 0
+    
+    gem_message_word_group = gem_message_word.group().strip()
+    return int(gem_message_word_group[len(gem_template_string_anchor):])
+
+def get_gem_count_in_message(message: str):
+    gem_count_in_message = message.count("💎")
+    if gem_count_in_message > 0:
+        return gem_count_in_message 
+    
+    return get_gem_count_from_gem_string(message)

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -1,0 +1,66 @@
+import unittest
+from src.command import GemsCounterFromMessage
+
+def assert_gem_count(unittest_instance, discord_message, expected_gems_count):
+    gems_count = GemsCounterFromMessage().get_gem_count_in_message(discord_message)
+    unittest_instance.assertEqual(gems_count, expected_gems_count)
+
+class TestGemsCounterFromGemMessage(unittest.TestCase):
+    def test_message_with_gem_returns_correct_gem_count(self):
+        assert_gem_count(self, '💎💎💎 for the help', 3)
+
+    def test_message_with_no_gem_returns_0_gem_count(self):
+        assert_gem_count(self, 'no gems given', 0)
+    
+    def test_message_with_extra_gem_returns_correct_gem_count(self):
+        assert_gem_count(self, '💎💎💎💎💎💎 for the help', 6)
+
+class TestGemsCounterFromStringMessage(unittest.TestCase):
+    def test_message_with_gem_string_returns_correct_gem_count(self):
+        assert_gem_count(self, '$gem-2 for the help', 2)
+    
+    def test_message_with_1000_gem_string_returns_correct_gem_count(self):
+        assert_gem_count(self, '$gem-1000 for the help', 1000)
+    
+    def test_message_with_0_gem_string_returns_correct_gem_count(self):
+        assert_gem_count(self, '$gem-0 for the help', 0)
+
+    def test_message_with_gem_string_with_multiple_spaces_returns_correct_gem_count(self):
+        assert_gem_count(self, '  $gem-2  for the help', 2)
+
+    def test_message_with_multiple_gem_strings_returns_first_gem_count(self):
+        assert_gem_count(self, '$gem-2 $gem-3 for the help', 2)
+    
+    def test_message_with_multiple_hyphens_in_gem_string_returns_integer_gem_count(self):
+        assert_gem_count(self, '$gem----3 for the help', 0)
+    
+    def test_message_with_decimal_number_gem_string_returns_integer_gem_count(self):
+        assert_gem_count(self, '$gem-10.12 for the help', 10)
+    
+    def test_message_with_gem_string_with_string_returns_0_gem_count(self):
+        assert_gem_count(self, '$gem-abcd for the help', 0)
+    
+    def test_message_with_gem_string_with_string_hyphen_number_returns_0_gem_count(self):
+        assert_gem_count(self, '$gem-abcd-10 for the help', 0)
+
+    def test_message_with_gem_string_with_string_and_number_returns_0_gem_count(self):
+        assert_gem_count(self, '$gem-abcd10 for the help', 0)
+    
+    def test_message_with_multiple_gem_strings_together_returns_0_count(self):
+        assert_gem_count(self, '$gem-2$gem-3 for the help', 0)
+    
+    def test_message_with_valid_and_invalid_gem_strings_returns_valid_count(self):
+        assert_gem_count(self, '$gem-abcde $gem-3 for the help', 3)
+
+    def test_message_with_no_gem_string_returns_0_gem_count(self):
+        assert_gem_count(self, 'no gems given', 0)
+
+class TestGemsAndGemsStringCounterFromMessage(unittest.TestCase):
+    def test_message_with_gem_and_gem_string_returns_gem_count(self):
+        assert_gem_count(self, '💎💎💎 $gem-5 for the help', 3)
+    
+    def test_message_with_gem_string_and_gem_returns_gem_count(self):
+        assert_gem_count(self, '$gem-5 💎💎💎 for the help', 3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -34,8 +34,8 @@ class TestGemsCounterFromStringMessage(unittest.TestCase):
     def test_message_with_multiple_hyphens_in_gem_string_returns_integer_gem_count(self):
         assert_gem_count(self, '$gem----3 for the help', 0)
     
-    def test_message_with_decimal_number_gem_string_returns_integer_gem_count(self):
-        assert_gem_count(self, '$gem-10.12 for the help', 10)
+    def test_message_with_decimal_number_gem_string_returns_0_gem_count(self):
+        assert_gem_count(self, '$gem-10.12 for the help', 0)
     
     def test_message_with_gem_string_with_string_returns_0_gem_count(self):
         assert_gem_count(self, '$gem-abcd for the help', 0)

--- a/test/test_message_gems_parser.py
+++ b/test/test_message_gems_parser.py
@@ -17,50 +17,50 @@ class TestGemsCounterFromGemMessage(unittest.TestCase):
 
 class TestGemsCounterFromStringMessage(unittest.TestCase):
     def test_message_with_gem_string_returns_correct_gem_count(self):
-        assert_gem_count(self, '$gem-2 for the help', 2)
+        assert_gem_count(self, '2-gems for the help', 2)
     
     def test_message_with_1000_gem_string_returns_correct_gem_count(self):
-        assert_gem_count(self, '$gem-1000 for the help', 1000)
+        assert_gem_count(self, '1000-gems for the help', 1000)
     
     def test_message_with_0_gem_string_returns_correct_gem_count(self):
-        assert_gem_count(self, '$gem-0 for the help', 0)
+        assert_gem_count(self, '0-gems for the help', 0)
 
     def test_message_with_gem_string_with_multiple_spaces_returns_correct_gem_count(self):
-        assert_gem_count(self, '  $gem-2  for the help', 2)
+        assert_gem_count(self, '  2-gems  for the help', 2)
 
     def test_message_with_multiple_gem_strings_returns_first_gem_count(self):
-        assert_gem_count(self, '$gem-2 $gem-3 for the help', 2)
+        assert_gem_count(self, '2-gems 3-gems for the help', 2)
     
     def test_message_with_multiple_hyphens_in_gem_string_returns_integer_gem_count(self):
-        assert_gem_count(self, '$gem----3 for the help', 0)
+        assert_gem_count(self, '3-----gems for the help', 0)
     
     def test_message_with_decimal_number_gem_string_returns_0_gem_count(self):
-        assert_gem_count(self, '$gem-10.12 for the help', 0)
+        assert_gem_count(self, '10.12-gems for the help', 0)
     
     def test_message_with_gem_string_with_string_returns_0_gem_count(self):
-        assert_gem_count(self, '$gem-abcd for the help', 0)
+        assert_gem_count(self, 'abcd-gems for the help', 0)
     
     def test_message_with_gem_string_with_string_hyphen_number_returns_0_gem_count(self):
-        assert_gem_count(self, '$gem-abcd-10 for the help', 0)
+        assert_gem_count(self, 'abcd-10-gems for the help', 0)
 
     def test_message_with_gem_string_with_string_and_number_returns_0_gem_count(self):
-        assert_gem_count(self, '$gem-abcd10 for the help', 0)
+        assert_gem_count(self, 'abcd10-gems for the help', 0)
     
     def test_message_with_multiple_gem_strings_together_returns_0_count(self):
-        assert_gem_count(self, '$gem-2$gem-3 for the help', 0)
+        assert_gem_count(self, '2-gems3-gems for the help', 0)
     
     def test_message_with_valid_and_invalid_gem_strings_returns_valid_count(self):
-        assert_gem_count(self, '$gem-abcde $gem-3 for the help', 3)
+        assert_gem_count(self, 'abcde-gems 3-gems for the help', 3)
 
     def test_message_with_no_gem_string_returns_0_gem_count(self):
         assert_gem_count(self, 'no gems given', 0)
 
 class TestGemsAndGemsStringCounterFromMessage(unittest.TestCase):
     def test_message_with_gem_and_gem_string_returns_gem_count(self):
-        assert_gem_count(self, '💎💎💎 $gem-5 for the help', 3)
+        assert_gem_count(self, '💎💎💎 5-gems for the help', 3)
     
     def test_message_with_gem_string_and_gem_returns_gem_count(self):
-        assert_gem_count(self, '$gem-5 💎💎💎 for the help', 3)
+        assert_gem_count(self, '5-gems 💎💎💎 for the help', 3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_message_gems_parser.py
+++ b/test/test_message_gems_parser.py
@@ -1,8 +1,8 @@
 import unittest
-from src.command import GemsCounterFromMessage
+from src.message_gems_parser import get_gem_count_in_message
 
 def assert_gem_count(unittest_instance, discord_message, expected_gems_count):
-    gems_count = GemsCounterFromMessage().get_gem_count_in_message(discord_message)
+    gems_count = get_gem_count_in_message(discord_message)
     unittest_instance.assertEqual(gems_count, expected_gems_count)
 
 class TestGemsCounterFromGemMessage(unittest.TestCase):

--- a/test/test_message_gems_parser.py
+++ b/test/test_message_gems_parser.py
@@ -17,50 +17,50 @@ class TestGemsCounterFromGemMessage(unittest.TestCase):
 
 class TestGemsCounterFromStringMessage(unittest.TestCase):
     def test_message_with_gem_string_returns_correct_gem_count(self):
-        assert_gem_count(self, '2-gems for the help', 2)
+        assert_gem_count(self, 'gems-2 for the help', 2)
     
     def test_message_with_1000_gem_string_returns_correct_gem_count(self):
-        assert_gem_count(self, '1000-gems for the help', 1000)
+        assert_gem_count(self, 'gems-1000 for the help', 1000)
     
     def test_message_with_0_gem_string_returns_correct_gem_count(self):
-        assert_gem_count(self, '0-gems for the help', 0)
+        assert_gem_count(self, 'gems-0 for the help', 0)
 
     def test_message_with_gem_string_with_multiple_spaces_returns_correct_gem_count(self):
-        assert_gem_count(self, '  2-gems  for the help', 2)
+        assert_gem_count(self, '  gems-2  for the help', 2)
 
     def test_message_with_multiple_gem_strings_returns_first_gem_count(self):
-        assert_gem_count(self, '2-gems 3-gems for the help', 2)
+        assert_gem_count(self, 'gems-2 gems-3 for the help', 2)
     
     def test_message_with_multiple_hyphens_in_gem_string_returns_integer_gem_count(self):
-        assert_gem_count(self, '3-----gems for the help', 0)
+        assert_gem_count(self, 'gems------3---- for the help', 0)
     
     def test_message_with_decimal_number_gem_string_returns_0_gem_count(self):
-        assert_gem_count(self, '10.12-gems for the help', 0)
+        assert_gem_count(self, 'gems-10.12 for the help', 0)
     
     def test_message_with_gem_string_with_string_returns_0_gem_count(self):
-        assert_gem_count(self, 'abcd-gems for the help', 0)
+        assert_gem_count(self, 'gems-abcd for the help', 0)
     
     def test_message_with_gem_string_with_string_hyphen_number_returns_0_gem_count(self):
-        assert_gem_count(self, 'abcd-10-gems for the help', 0)
+        assert_gem_count(self, 'gems-abcd-10 for the help', 0)
 
     def test_message_with_gem_string_with_string_and_number_returns_0_gem_count(self):
-        assert_gem_count(self, 'abcd10-gems for the help', 0)
+        assert_gem_count(self, 'gems-abcd10 for the help', 0)
     
     def test_message_with_multiple_gem_strings_together_returns_0_count(self):
-        assert_gem_count(self, '2-gems3-gems for the help', 0)
+        assert_gem_count(self, 'gems-2gems-3 for the help', 0)
     
     def test_message_with_valid_and_invalid_gem_strings_returns_valid_count(self):
-        assert_gem_count(self, 'abcde-gems 3-gems for the help', 3)
+        assert_gem_count(self, 'gems-abcde gems-3 for the help', 3)
 
     def test_message_with_no_gem_string_returns_0_gem_count(self):
         assert_gem_count(self, 'no gems given', 0)
 
 class TestGemsAndGemsStringCounterFromMessage(unittest.TestCase):
     def test_message_with_gem_and_gem_string_returns_gem_count(self):
-        assert_gem_count(self, '💎💎💎 5-gems for the help', 3)
+        assert_gem_count(self, '💎💎💎 gems-5 for the help', 3)
     
     def test_message_with_gem_string_and_gem_returns_gem_count(self):
-        assert_gem_count(self, '5-gems 💎💎💎 for the help', 3)
+        assert_gem_count(self, 'gems-5 💎💎💎 for the help', 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #29 

# Description
In current implementation, gem count is determined by the `:gem:` string in the discord message. It introduces the template `gems-number` to provide gems with a number, rather than having to type the string `:gem:` repeatedly. example: `gems-3 for the help` will return the gem count as 3 from this message.

This template works besides the existing implementation. It adds the template as an addition, without changing the existing implementation. This means, a user can use both the current way, and the `template` way to send gems.

Unit tests have been added for counting gems from message string. The tests are divided into 3 test classes (in the same file), validating current implementation behaviour, validating template string behaviour, and validating using both in the same message. 

Giving a number of examples below to clarify the implemented behaviour:
- `gems-3 for the help` will return 3 gem count.
- `gems-35 for the help` will return 35 gem count.
- `gems-3 gems-35 for the help` will return 3 gem count.
- `gems-3gems-35 for the help` will return 0 gem count.
- `gems-----35 for the help` will return 0 gem count.
- `gems-10.8 for the help` will return 0 gem count.
- `gems-abcd gems-35 for the help` will return 35 gem count.
- Using both `:gem:` and `gems-number` returns the count of `:gem:` and disregards the template.

Please check the tests to understand the implemented behaviour for these cases.
