### PR TITLE
adding ttl to ddb

### DIFF
--- a/src/dynamo.py
+++ b/src/dynamo.py
@@ -34,7 +34,7 @@ class GemsModel(Model):
     receiver = UnicodeAttribute()
     gem_count = NumberAttribute()
     date = UnicodeAttribute()
-    expire_after = UnicodeAttribute()
+    remove_after = UnicodeAttribute()
 
     date_index = DateIndex()
 
@@ -102,6 +102,6 @@ def insert_gem_to_dynamo(gems_message: GemsMessage):
         receiver=gems_message.receiver_discord_id,
         gem_count=gems_message.gem_count,
         date=datetime.datetime.today().strftime(DATE_FORMAT),
-        expire_after=time.time() + THIRTY_ONE_DAYS_IN_SECONDS
+        remove_after=time.time() + THIRTY_ONE_DAYS_IN_SECONDS
     )
     gems.save()

--- a/src/dynamo.py
+++ b/src/dynamo.py
@@ -2,6 +2,7 @@
 import calendar
 import datetime
 import os
+import time
 import uuid
 from typing import Dict, List, Optional
 
@@ -12,6 +13,7 @@ from pynamodb.models import Model
 from command import GemsMessage
 
 DATE_FORMAT = "%Y-%m-%d"
+THIRTY_ONE_DAYS_IN_SECONDS = 60 * 60 * 24 * 31
 
 
 class DateIndex(GlobalSecondaryIndex):
@@ -32,6 +34,7 @@ class GemsModel(Model):
     receiver = UnicodeAttribute()
     gem_count = NumberAttribute()
     date = UnicodeAttribute()
+    expire_after = UnicodeAttribute()
 
     date_index = DateIndex()
 
@@ -98,6 +101,7 @@ def insert_gem_to_dynamo(gems_message: GemsMessage):
         sender=gems_message.sender_discord_id,
         receiver=gems_message.receiver_discord_id,
         gem_count=gems_message.gem_count,
-        date=datetime.datetime.today().strftime(DATE_FORMAT)
+        date=datetime.datetime.today().strftime(DATE_FORMAT),
+        expire_after=time.time() + THIRTY_ONE_DAYS_IN_SECONDS
     )
     gems.save()

--- a/terraform/dynamo.tf
+++ b/terraform/dynamo.tf
@@ -14,6 +14,11 @@ resource "aws_dynamodb_table" "gems_table" {
     type = "S"
   }
 
+  ttl {
+    attribute_name = "remove_after"
+    enabled        = true
+  }
+
   global_secondary_index {
     name               = "date-index"
     hash_key           = "date"


### PR DESCRIPTION
This is re: #23 
We only use data from the last month to create ranks or insert values. Which means technically speaking, we don't really need to store anything past a month. This Pr tries to address that by adding dynamodb ttl columns. Which has *no additional cost* but helps us reduce the time it takes to scan the table and general savings for the amount of data that we will end up storing. I haven't deployed this to be honest but looking for some reviews to see if the approach is okay before I setup the dummy bot to test.
Why 31 Days Sakib?
Makes sense to store for the worst case scenario.
What about the stuff that already exists?
We'll have to write a script to clean that up