### PR TITLE
Gems string template replaced with gems in discord message

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -10,6 +10,7 @@ from nacl.signing import VerifyKey
 from command import GemsMessage, is_rank_command, slash_command_response
 from communication import send_channel_message
 from constants import load_environment_variables
+from message_gems_decorator import replace_gem_template_with_real_gem
 from dynamo import (get_monthly_rank, insert_gem_to_dynamo,
                     sender_gem_count_today)
 
@@ -96,7 +97,7 @@ def gem_handler(body: Dict[str, Any], env_vars):
             return slash_command_response(
                 f"**:heart_eyes: {gems_message.sender_username} to **"
                 f"<@{gems_message.receiver_discord_id}>: "
-                f"{gems_message.gem_message}"
+                f"{replace_gem_template_with_real_gem(gems_message.gem_message, gems_message.gem_count)}"
             )
         else:
             return slash_command_response(

--- a/src/message_gems_decorator.py
+++ b/src/message_gems_decorator.py
@@ -1,0 +1,17 @@
+import re
+from .message_gems_parser import gem_message_string_regex
+
+def replace_gem_template_with_real_gem(message_with_gem_template: str, gem_count: int):
+    if '💎' in message_with_gem_template or gem_count == 0:
+        return message_with_gem_template
+    
+    gem_substituted_message = re.sub(gem_message_string_regex, '💎' * gem_count, message_with_gem_template)
+
+    if gem_substituted_message[0] != '💎':
+        gem_substituted_message = gem_substituted_message.replace('💎', ' 💎', 1)
+    
+    gem_last_index = gem_substituted_message.rfind('💎')
+    if gem_last_index != -1 and gem_last_index != len(gem_substituted_message) - 1:
+        gem_substituted_message = gem_substituted_message[:gem_last_index] + '💎 ' + gem_substituted_message[gem_last_index + 1:]
+
+    return gem_substituted_message

--- a/src/message_gems_parser.py
+++ b/src/message_gems_parser.py
@@ -1,8 +1,9 @@
 import re
 
+gem_template_string_anchor = 'gems-'
+gem_message_string_regex = fr'(?:\s|^){gem_template_string_anchor}\d+(?:\s|$)'
+
 def get_gem_count_from_gem_string(message: str):
-    gem_template_string_anchor = 'gems-'
-    gem_message_string_regex = fr'(?:\s|^){gem_template_string_anchor}\d+(?:\s|$)'
     probable_gem_message_word = re.search(gem_message_string_regex, message)
     if not probable_gem_message_word:
         return 0

--- a/test/test_message_gems_decorator.py
+++ b/test/test_message_gems_decorator.py
@@ -1,0 +1,43 @@
+import unittest
+from src.message_gems_decorator import replace_gem_template_with_real_gem
+
+def assert_decorated_gem_message_correctness(unittest_instance, discord_message, gem_count, expected_message):
+    decorated_message = replace_gem_template_with_real_gem(discord_message, gem_count)
+    unittest_instance.assertEqual(decorated_message, expected_message)
+    unittest_instance.assertEqual(decorated_message.count('💎'), gem_count)
+
+class TestGemsMessageDecorator(unittest.TestCase):
+    def test_message_with_gem_template_string_constructs_message_with_correct_gem_count(self):
+        decorated_message = '💎💎💎💎 for the help'
+        assert_decorated_gem_message_correctness(self, 'gems-4 for the help', 4, decorated_message)
+
+    def test_message_with_gem_template_string_constructs_message_with_correct_gem_count(self):
+        decorated_message = '💎 for the help'
+        assert_decorated_gem_message_correctness(self, 'gems-1 for the help', 1, decorated_message)
+    
+    def test_message_with_gem_template_string_constructs_message_with_correct_gem_count(self):
+        decorated_message = 'gems-0 for the help'
+        assert_decorated_gem_message_correctness(self, 'gems-0 for the help', 0, decorated_message)
+
+    def test_message_with_multiple_gem_template_string_constructs_message_with_first_converted_to_gem(self):
+        decorated_message = '💎💎💎💎 gems-3 for the help'
+        assert_decorated_gem_message_correctness(self, 'gems-4 gems-3 for the help', 4, decorated_message)
+    
+    def test_message_with_gem_template_string_and_gem_remains_unchanged(self):
+        decorated_message = '💎💎💎 gems-4 for the help'
+        assert_decorated_gem_message_correctness(self, '💎💎💎 gems-4 for the help', 3, decorated_message)
+    
+    def test_message_with_gem_template_string_and_gem_remains_unchanged(self):
+        decorated_message = '💎💎💎 gems-4 for the help'
+        assert_decorated_gem_message_correctness(self, '💎💎💎 gems-4 for the help', 3, decorated_message)
+
+    def test_message_with_gem_template_string_in_middle_constructs_message_with_correct_gem_count(self):
+        decorated_message = 'giving 💎💎💎 to you for the help'
+        assert_decorated_gem_message_correctness(self, 'giving gems-3 to you for the help', 3, decorated_message)
+    
+    def test_message_with_invalid_gem_template_string_remains_unchanged(self):
+        decorated_message = 'gems-1234abcd for the help'
+        assert_decorated_gem_message_correctness(self, 'gems-1234abcd for the help', 0, decorated_message)
+    
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Follow up PR for #30 

Replaces the `gems-number` string template with `:gem:` in the sent back discord message