### PR TITLE
fix opt-out message spacing and add permission to delete DDB item

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -93,10 +93,7 @@ def gem_handler(body: Dict[str, Any], env_vars):
 
         if has_receiver_opted_out(gems_message.receiver_discord_id):
             receiver = gems_message.receiver_username if hasattr(gems_message, 'receiver_username') else 'Recipient'
-            return slash_command_response(f"""
-                **{emojis.PLEADING_FACE} {receiver} has chosen solitude and is temporarily not receiving any gems. 
-                Thank you for the acknowledgment, by the way {emojis.HEART}**
-            """)
+            return slash_command_response(f"**{emojis.PLEADING_FACE} {receiver} has chosen solitude and is temporarily not receiving any gems. Thank you for your acknowledgment {emojis.HEART}**")
 
         if gems_message.sender_discord_id == gems_message.receiver_discord_id:
             return self_gem(gems_message)

--- a/terraform/lambda_iam_policy.tf
+++ b/terraform/lambda_iam_policy.tf
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "discord_gems_policy" {
       "dynamodb:Scan",
       "dynamodb:Query",
       "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
       "dynamodb:DescribeTable",
     ]
     resources = [


### PR DESCRIPTION
Added dynamodb DeleteItem permission for the `opt-in` command functionality, and removed unnecessary spacing from the opt-out message.